### PR TITLE
KaTeX Rendering by Exam Board Preference

### DIFF
--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -99,7 +99,7 @@ export interface UserEmailPreferences {
 export interface UserPreferencesDTO {
     BETA_FEATURE?: string;
     EMAIL_PREFERENCE?: UserEmailPreferences;
-    EXAM_BOARD?: {AQA: boolean; OCR: boolean};
+    EXAM_BOARD?: {[EXAM_BOARD.AQA]: boolean; [EXAM_BOARD.OCR]: boolean};
 }
 
 export interface ValidatedChoice<C extends ApiTypes.ChoiceDTO> {

--- a/src/IsaacAppTypes.tsx
+++ b/src/IsaacAppTypes.tsx
@@ -1,5 +1,5 @@
 import * as ApiTypes from "./IsaacApiTypes";
-import {ACTION_TYPE, DOCUMENT_TYPE, TAG_ID} from "./app/services/constants";
+import {ACTION_TYPE, DOCUMENT_TYPE, EXAM_BOARD, TAG_ID} from "./app/services/constants";
 import {RegisteredUserDTO} from "./IsaacApiTypes";
 
 export type Action =
@@ -99,7 +99,7 @@ export interface UserEmailPreferences {
 export interface UserPreferencesDTO {
     BETA_FEATURE?: string;
     EMAIL_PREFERENCE?: UserEmailPreferences;
-    SUBJECT_INTEREST?: string;
+    EXAM_BOARD?: {AQA: boolean; OCR: boolean};
 }
 
 export interface ValidatedChoice<C extends ApiTypes.ChoiceDTO> {

--- a/src/app/components/elements/TrustedHtml.tsx
+++ b/src/app/components/elements/TrustedHtml.tsx
@@ -30,6 +30,7 @@ const Macros: {[key: string]: MathJaxMacro} = {
     "and": ["{#1} \\wedge {#2}", 2],
     "or": ["{#1} \\lor {#2}", 2],
     "not": ["\\lnot{#1}", 1],
+    "bracketnot": ["\\lnot{(#1)}", 1],
     "xor": ["{#1} \\veebar {#2}", 2],
     "equivalent": "\\equiv"
 };

--- a/src/app/components/elements/TrustedHtml.tsx
+++ b/src/app/components/elements/TrustedHtml.tsx
@@ -8,8 +8,9 @@ import {connect} from "react-redux";
 
 type MathJaxMacro = string|[string, number];
 
-const Macros: {[key: string]: MathJaxMacro} = {
+const BaseMacros: {[key: string]: MathJaxMacro} = {
     // See http://docs.mathjax.org/en/latest/tex.html#defining-tex-macros
+    // Mathematics:
     "quantity": ["{#1}\\,{\\rm{#2}}", 2],
     "valuedef": ["{#1}={\\quantity{#2}{#3}}", 3],
     "vtr": ["{\\underline{\\boldsymbol{#1}}}", 1],
@@ -24,7 +25,8 @@ const Macros: {[key: string]: MathJaxMacro} = {
     "units": ["\\rm{#1}", 1],
     // Chemistry:
     "standardstate": ["\\mathbin{\u29B5}", 0],
-    // Boolean Algebra:
+};
+const BooleanLogicMathsMacros: {[key: string]: MathJaxMacro} = {
     "true": "\\boldsymbol{\\rm{T}}",
     "false": "\\boldsymbol{\\rm{F}}",
     "and": ["{#1} \\wedge {#2}", 2],
@@ -34,23 +36,40 @@ const Macros: {[key: string]: MathJaxMacro} = {
     "xor": ["{#1} \\veebar {#2}", 2],
     "equivalent": "\\equiv"
 };
+const BooleanLogicEngineeringMacros: {[key: string]: MathJaxMacro} = {
+    "and" : ["{#1} \\cdot {#2}", 2],
+    "or" : ["{#1} + {#2}", 2],
+    "not" : ["\\overline{#1}", 1],
+    "bracketnot" : ["\\overline{#1}", 1], // Don't do anything different to "not" for engineering syntax!
+    "xor" : ["{#1} \\oplus {#2}", 2],
+    "true" : "1",
+    "false" : "0",
+    "equivalent" : "=",
+};
 
-const KatexMacros = Object.keys(Macros).reduce((acc, key) => {
-    const name = "\\" + key;
-    let value: MathJaxMacro = Macros[key];
-    if (typeof value != 'string') {
-        value = value[0];
-    }
-    // @ts-ignore
-    acc[name] = value;
-    return acc;
-}, {});
+function mathjaxToKatex(macros: {[key: string]: MathJaxMacro}) {
+    return Object.keys(macros).reduce((acc, key) => {
+        const name = "\\" + key;
+        let value: MathJaxMacro = macros[key];
+        if (typeof value != 'string') {
+            value = value[0];
+        }
+        // @ts-ignore
+        acc[name] = value;
+        return acc;
+    }, {});
+}
+
+// Create MathJax versions for each of the two syntaxes, then create KaTeX versions of those:
+const MacrosWithMathsBoolean = Object.assign({}, BaseMacros, BooleanLogicMathsMacros);
+const MacrosWithEngineeringBoolean = Object.assign({}, BaseMacros, BooleanLogicEngineeringMacros);
+const KatexMacrosWithMathsBool = mathjaxToKatex(MacrosWithMathsBoolean);
+const KatexMacrosWithEngineeringBool = mathjaxToKatex(MacrosWithEngineeringBoolean);
 
 const KatexOptions = {
     throwOnError: false,
     strict: false,
     colorIsTextColor: true,
-    macros: KatexMacros // NB: Katex can modify this, so check if definitions are spilling over between nodes
 };
 
 function patternQuote(s: string) {
@@ -192,7 +211,12 @@ export function katexify(html: string, userPreferences: UserPreferencesDTO | nul
                 const latex = html.substring(index + (search.olen || 0), match.index + match[0].length - (search.clen || 0));
                 const latexUnEntitied = he.decode(latex);
                 const latexMunged = munge(latexUnEntitied);
-                output += katex.renderToString(latexMunged, {...KatexOptions, displayMode: search.mode == "display"});
+                let macrosToUse = KatexMacrosWithMathsBool;
+                if (userPreferences && userPreferences.EXAM_BOARD && userPreferences.EXAM_BOARD.AQA) {
+                    macrosToUse = KatexMacrosWithEngineeringBool;
+                }
+                output += katex.renderToString(latexMunged,
+                    {...KatexOptions, displayMode: search.mode == "display", macros: macrosToUse});
                 index = match.index + match[0].length;
             } else {
                 // Unmatched start, so output the start and continue searching from after it.

--- a/src/app/components/elements/TrustedHtml.tsx
+++ b/src/app/components/elements/TrustedHtml.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import katex from "katex";
 import '../../services/mhchem';
 import he from "he";
+import {UserPreferencesDTO} from "../../../IsaacAppTypes";
+import {AppState} from "../../state/reducers";
+import {connect} from "react-redux";
 
 type MathJaxMacro = string|[string, number];
 
@@ -165,7 +168,7 @@ function munge(latex: string) {
         .replace(/\\newline/g, "\\\\");
 }
 
-export function katexify(html: string) {
+export function katexify(html: string, userPreferences: UserPreferencesDTO | null) {
     start.lastIndex = 0;
     let match: RegExpExecArray | null;
     let output = "";
@@ -221,11 +224,25 @@ function bootstrapify(html: string) {
     return bootstrappedHtml;
 }
 
-export const TrustedHtml = ({html, span}: {html: string; span?: boolean}) => {
-    html = bootstrapify(katexify(html));
+
+
+const stateToProps = (state: AppState) => ({
+    userPreferences: state ? state.userPreferences : null
+});
+
+interface TrustedHtmlProps {
+    html: string;
+    span?: boolean;
+    userPreferences: UserPreferencesDTO | null
+}
+
+let TrustedHtmlComponent = ({html, span, userPreferences}: TrustedHtmlProps) => {
+    html = bootstrapify(katexify(html, userPreferences));
     if (span) {
         return <span dangerouslySetInnerHTML={{__html: html}} />;
     } else {
         return <div dangerouslySetInnerHTML={{__html: html}} />;
     }
 };
+
+export const TrustedHtml = connect(stateToProps)(TrustedHtmlComponent);

--- a/src/app/components/elements/TrustedHtml.tsx
+++ b/src/app/components/elements/TrustedHtml.tsx
@@ -258,7 +258,7 @@ const stateToProps = (state: AppState) => ({
 interface TrustedHtmlProps {
     html: string;
     span?: boolean;
-    userPreferences: UserPreferencesDTO | null
+    userPreferences: UserPreferencesDTO | null;
 }
 
 let TrustedHtmlComponent = ({html, span, userPreferences}: TrustedHtmlProps) => {

--- a/src/test/components/TrustedHtml.test.tsx
+++ b/src/test/components/TrustedHtml.test.tsx
@@ -1,6 +1,7 @@
 import katex from "katex";
 
 import {katexify} from '../../app/components/elements/TrustedHtml';
+import {EXAM_BOARD} from "../../app/services/constants";
 
 jest.mock("katex");
 
@@ -27,7 +28,7 @@ describe('TrustedHtml LaTeX locator', () => {
     it('can find basic delimiters', () => {
         delimiters.forEach(([open, displayMode, close]) => {
             const testcase = html[0] + wrapIn(open, math[0], close) + html[1];
-            const result = katexify(testcase);
+            const result = katexify(testcase, null);
 
             expect(result).toEqual(html[0] + LATEX + html[1]);
             // @ts-ignore
@@ -40,7 +41,7 @@ describe('TrustedHtml LaTeX locator', () => {
     it("unbalanced delimiters don't break everything but instead are just skipped", () => {
         delimiters.forEach(([open, , ]) => {
             const testcase = html[0] + wrapIn(open, math[0], "") + html[1];
-            const result = katexify(testcase);
+            const result = katexify(testcase, null);
 
             expect(result).toEqual(html[0] + open + math[0] + html[1]);
             expect(katex.renderToString).not.toHaveBeenCalled();
@@ -51,7 +52,7 @@ describe('TrustedHtml LaTeX locator', () => {
         nestedDollars.forEach((dollarMath) => {
             delimiters.forEach(([open, displayMode, close]) => {
                 const testcase = html[0] + wrapIn(open, dollarMath, close) + html[1];
-                const result = katexify(testcase);
+                const result = katexify(testcase, null);
 
                 expect(result).toEqual(html[0] + LATEX + html[1]);
                 // @ts-ignore
@@ -65,7 +66,7 @@ describe('TrustedHtml LaTeX locator', () => {
     it('can render environments', () => {
         const env = "\\begin{aligned}" + math[0] + "\\end{aligned}";
         const testcase = html[0] + env + html[1];
-        const result = katexify(testcase);
+        const result = katexify(testcase, null);
 
         expect(result).toEqual(html[0] + LATEX + html[1]);
         // @ts-ignore
@@ -77,7 +78,7 @@ describe('TrustedHtml LaTeX locator', () => {
     it('refs are currently ignored', () => {
         const ref = "\\ref{foo[234o89tdgfiuno34£\"$%^Y}";
         const testcase = html[0] + ref + html[1];
-        const result = katexify(testcase);
+        const result = katexify(testcase, null);
 
         expect(result).toEqual(html[0] + ref + html[1]);
         expect(katex.renderToString).not.toHaveBeenCalled();
@@ -87,7 +88,7 @@ describe('TrustedHtml LaTeX locator', () => {
         const escapedDollar = "\\$";
         const unescapedDollar = "$";
         const testcase = html[0] + escapedDollar + html[1];
-        const result = katexify(testcase);
+        const result = katexify(testcase, null);
 
         expect(result).toEqual(html[0] + unescapedDollar + html[1]);
         expect(katex.renderToString).not.toHaveBeenCalled();


### PR DESCRIPTION
This allows use of `EXAM_BOARD` as a user preference to determine which boolean algebra syntax will be displayed to the user. We default to "mathematician syntax", as used in propositional and formal logic and by the OCR exam board.