### PR TITLE
Add exam board filtering to search results

### DIFF
--- a/src/app/components/pages/Search.tsx
+++ b/src/app/components/pages/Search.tsx
@@ -102,9 +102,9 @@ const SearchPageComponent = (props: SearchPageProps) => {
         return keepElement || isStaffUser;
     };
 
-    const filteredSearchResults = searchResults && searchResults.results && searchResults.results.filter(filterResult);
+    const filteredSearchResults = searchResults && searchResults.results && filterOnExamBoard(searchResults.results.filter(filterResult), examBoard);
 
-    const shortcutSearchResults = filterOnExamBoard(((shortcutResponse || []).concat(filteredSearchResults || [])), examBoard);
+    const shortcutAndFilteredSearchResults = (shortcutResponse || []).concat(filteredSearchResults || []);
 
     return (
         <Container id="search-page">
@@ -131,7 +131,7 @@ const SearchPageComponent = (props: SearchPageProps) => {
                         <RS.CardHeader className="search-header">
                             <Col md={5} xs={12}>
                                 <h3>
-                                    <span className="d-none d-sm-inline-block">Search&nbsp;</span>Results {query != "" ? shortcutSearchResults ? <RS.Badge color="primary">{shortcutSearchResults.length}</RS.Badge> : <RS.Spinner color="primary" /> : null}
+                                    <span className="d-none d-sm-inline-block">Search&nbsp;</span>Results {query != "" ? shortcutAndFilteredSearchResults ? <RS.Badge color="primary">{shortcutAndFilteredSearchResults.length}</RS.Badge> : <RS.Spinner color="primary" /> : null}
                                 </h3>
                             </Col>
                             <Col md={7} xs={12}>
@@ -144,9 +144,9 @@ const SearchPageComponent = (props: SearchPageProps) => {
                             </Col>
                         </RS.CardHeader>
                         {query != "" && <RS.CardBody>
-                            <ShowLoading until={shortcutSearchResults}>
-                                {shortcutSearchResults && shortcutSearchResults.length > 0 ?
-                                    <LinkToContentSummaryList items={shortcutSearchResults}/>
+                            <ShowLoading until={shortcutAndFilteredSearchResults}>
+                                {shortcutAndFilteredSearchResults && shortcutAndFilteredSearchResults.length > 0 ?
+                                    <LinkToContentSummaryList items={shortcutAndFilteredSearchResults}/>
                                     : <em>No results found</em>}
                             </ShowLoading>
                         </RS.CardBody>}

--- a/src/app/services/examBoard.ts
+++ b/src/app/services/examBoard.ts
@@ -1,5 +1,6 @@
-import {EXAM_BOARD} from "./constants";
+import {EXAM_BOARD, examBoardTagMap} from "./constants";
 import {UserPreferencesDTO} from "../../IsaacAppTypes";
+import {ContentSummaryDTO} from "../../IsaacApiTypes";
 
 export const determineExamBoardFrom = (userPreferences?: UserPreferencesDTO | null) => {
     if (userPreferences && userPreferences.EXAM_BOARD && userPreferences.EXAM_BOARD.AQA) {
@@ -7,4 +8,9 @@ export const determineExamBoardFrom = (userPreferences?: UserPreferencesDTO | nu
     } else {
         return EXAM_BOARD.OCR;
     }
+};
+
+export const filterOnExamBoard = (contents: ContentSummaryDTO[], examBoard: EXAM_BOARD) => {
+    console.log(examBoard);
+    return contents.filter(content => content.tags && content.tags.includes(examBoardTagMap[examBoard]));
 };

--- a/src/app/services/examBoard.ts
+++ b/src/app/services/examBoard.ts
@@ -11,6 +11,5 @@ export const determineExamBoardFrom = (userPreferences?: UserPreferencesDTO | nu
 };
 
 export const filterOnExamBoard = (contents: ContentSummaryDTO[], examBoard: EXAM_BOARD) => {
-    console.log(examBoard);
     return contents.filter(content => content.tags && content.tags.includes(examBoardTagMap[examBoard]));
 };

--- a/src/app/services/topics.ts
+++ b/src/app/services/topics.ts
@@ -10,10 +10,7 @@ import {
 import {CurrentTopicState} from "../state/reducers";
 import {LinkInfo} from "./navigation";
 import {NOT_FOUND_TYPE} from "../../IsaacAppTypes";
-
-const filterOnExamBoard = (contents: ContentSummaryDTO[], examBoard: EXAM_BOARD) => {
-    return contents.filter(content => content.tags && content.tags.includes(examBoardTagMap[examBoard]));
-};
+import {filterOnExamBoard} from "./examBoard";
 
 const filterForConcepts = (contents: ContentSummaryDTO[]) => {
     return contents.filter(content => content.type === DOCUMENT_TYPE.CONCEPT);


### PR DESCRIPTION
- Moves filterOnExamBoard to `examBoard` service from the `topics` service.
- Filters search results based on user specified exam board
- Provides Anon user choice like topics in the filter section