### PR TITLE
Add very minimal print CSS configuration

### DIFF
--- a/src/app/components/elements/ListGroupFooterBottom.tsx
+++ b/src/app/components/elements/ListGroupFooterBottom.tsx
@@ -20,7 +20,7 @@ export const ListGroupFooterBottom = () => (
                 </p>
             </ListGroupItem>
 
-            <ListGroupItem className='footer-bottom-logos border-0 px-0 py-0 pb-4 pb-md-1 bg-transparent d-flex justify-content-between'>
+            <ListGroupItem className='footer-bottom-logos border-0 px-0 py-0 pb-4 pb-md-1 bg-transparent d-flex justify-content-between d-print-none'>
                 <ExternalLink href="https://teachcomputing.org/">
                     <img src="/assets/logos/ncce.png" alt='National Centre for Computing Education website' className='logo-mr' height="57px" />
                 </ExternalLink>

--- a/src/app/components/navigation/CookieBanner.tsx
+++ b/src/app/components/navigation/CookieBanner.tsx
@@ -20,7 +20,7 @@ const CookieBannerComponent = ({logAction}: {logAction: (eventDetails: object) =
         logAction(eventDetails);
     }
 
-    return show ? <div className="banner">
+    return show ? <div className="banner d-print-none">
         <RS.Container className="py-3">
             <RS.Row style={{alignItems: "center"}}>
                 <RS.Col xs={12} sm={2} md={1}>

--- a/src/app/components/navigation/EmailVerificationBanner.tsx
+++ b/src/app/components/navigation/EmailVerificationBanner.tsx
@@ -35,7 +35,7 @@ const EmailVerificationBannerComponent = ({user, requestEmailVerification}: Emai
 
     const show = user != null && user.loggedIn && status != "VERIFIED" && !hidden;
 
-    return show ? <div className="banner">
+    return show ? <div className="banner d-print-none">
         <RS.Container className="py-3">
 
             <RS.Row style={{alignItems: "center"}}>

--- a/src/app/components/navigation/Footer.tsx
+++ b/src/app/components/navigation/Footer.tsx
@@ -14,7 +14,7 @@ const ExternalLink = ({href, children}: {href: string; children: any}) => (
 
 export const Footer = () => (
     <footer>
-        <div className="footerTop">
+        <div className="footerTop d-print-none">
             <Container>
                 <Row className="pt-5 px-3 px-sm-0 pb-3 pb-md-5">
                     <Col md='4' lg='3' className="logo-col">

--- a/src/app/components/navigation/Header.tsx
+++ b/src/app/components/navigation/Header.tsx
@@ -28,7 +28,7 @@ const HeaderComponent = ({user}: HeaderProps) => {
                             <div id="beta-banner">beta</div>
                         </div>
 
-                        <div className="header-links ml-auto pr-3 px-md-3 d-flex align-items-center">
+                        <div className="header-links ml-auto pr-3 px-md-3 d-flex align-items-center d-print-none">
                             {user &&
                                 (!user.loggedIn ?
                                     <React.Fragment>
@@ -60,7 +60,7 @@ const HeaderComponent = ({user}: HeaderProps) => {
                             }
                         </div>
 
-                        <div className="header-search m-md-0 ml-md-auto align-items-center">
+                        <div className="header-search m-md-0 ml-md-auto align-items-center d-print-none">
                             <MainSearch />
                         </div>
                     </div>

--- a/src/scss/isaac.scss
+++ b/src/scss/isaac.scss
@@ -93,6 +93,9 @@ $tertiary-font: 'arconrounded-regular', sans-serif;
 @import "./assignment-progress";
 @import "./groups";
 
+// Print
+@import "./print";
+
 a.disabled {
     color: $gray-600;
     pointer-events: none;

--- a/src/scss/print.scss
+++ b/src/scss/print.scss
@@ -1,0 +1,19 @@
+@media print {
+
+  .accordion {
+    page-break-inside: avoid;
+  }
+
+  .content-body {
+    background-color: white !important;
+  }
+
+  .collapse {
+    display: initial !important;
+  }
+
+  .container {
+    max-width: none;
+  }
+
+}


### PR DESCRIPTION
We may want to move these into their relevant existing SCSS files?

To preview this most easily, [follow these instructions for Chrome](https://developers.google.com/web/tools/chrome-devtools/css/print-preview).


Also, removes some things that shouldn't be printed.