### PR TITLE
Make the noscript page look nicer using Bootstrap classes and logo

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,8 +40,25 @@
     <title>Isaac Computer Science</title>
   </head>
   <body>
-    <noscript>You need to enable JavaScript to use Isaac Computer Science.</noscript>
-    <div id="root" class="d-flex flex-column min-vh-100 overflow-hidden"></div>
+    <noscript>
+      <div class="fixed-top bg-primary">
+        <img src="/assets/logo.svg" alt="Isaac Computer Science Logo" class="p-3" />
+      </div>
+      <div class="my-5 py-5"></div>
+      <div class="container">
+        <div class="row">
+          <div class="col-8 offset-2">
+            <div class="card">
+              <div class="card-body text-center">
+                <h1>Isaac Computer Science</h1>
+                <p class="pt-3">You need to enable JavaScript to access Isaac Computer Science.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </noscript>
+    <div id="root" class="d-flex flex-column overflow-hidden"></div>
     <script src="https://cdn.isaaccomputerscience.org/vendor/youtube/iframe_api.js" async></script>
   </body>
 </html>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,11 +6,20 @@ import {Provider} from "react-redux";
 import {store} from "./app/state/store";
 import IsaacApp from './app/components/navigation/IsaacApp';
 
-ReactDOM.render(
-    <React.StrictMode>
-        <Provider store={store}>
-            <IsaacApp />
-        </Provider>
-    </React.StrictMode>,
-    document.getElementById('root')
-);
+let rootElement = document.getElementById('root');
+
+if (rootElement) {
+
+    // Cannot add this class to the root element without JavaScript because
+    // it messes up the page formatting for the <noscript> case!
+    rootElement.classList.add("min-vh-100");
+
+    ReactDOM.render(
+        <React.StrictMode>
+            <Provider store={store}>
+                <IsaacApp />
+            </Provider>
+        </React.StrictMode>,
+        rootElement
+    );
+}


### PR DESCRIPTION
This cannot easily be previewed locally, because the stylesheets are loaded by JavaScript in the development server. To actually see the page locally, you need to build the minified version and then serve it using a static server (e.g. `python2 -m SimpeHTTPServer 8003`) from the `build` directory.

The layout falls back gracefully without CSS though!

I'm not sure I like `rootElement.classList.add("min-vh-100");`, but the class is required to make sure the page takes up the full height, and it does add an unnecessary scroll-bar on the noscript page if left in by default. Adding it by JavaScript seems an acceptable compromise for these two?