### PR TITLE
Replace repeating background with css resized

### DIFF
--- a/public/assets/Line-alt.svg
+++ b/public/assets/Line-alt.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1" height="90" viewBox="0 0 1 90">
+<svg preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" width="1" height="90" viewBox="0 0 1 90">
   <path fill="none" stroke="#FFB53F" stroke-linecap="square" d="M0.5,0.5 L0.5,89.5"/>
 </svg>

--- a/public/assets/Line.svg
+++ b/public/assets/Line.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1" height="139" viewBox="0 0 1 139">
+<svg preserveAspectRatio="none" xmlns="http://www.w3.org/2000/svg" width="1" height="139" viewBox="0 0 1 139">
   <path fill="none" stroke="#FFB53F" stroke-linecap="square" d="M0.5,0.5 L0.5,138.5"/>
 </svg>

--- a/src/scss/header.scss
+++ b/src/scss/header.scss
@@ -74,11 +74,13 @@ header {
 
 header {
   background-image: url('/assets/Line.svg');
-  background-repeat: repeat-x;
+  background-size: 100%;
+  background-repeat: no-repeat;
   position: relative;
 
   @include respond-above(sm) {
     background-image: url('/assets/Line-alt.svg');
+    background-size: 100% 60%;
   }
 
   > .container {


### PR DESCRIPTION
The header previously consister of repeated svg lines. This produced
white stripes in Chrome at certain zoom levels.

Fixed by simply resizing the svg to cover the required area