### PR TITLE
Make question buttons underlined when focused

### DIFF
--- a/src/scss/questions.scss
+++ b/src/scss/questions.scss
@@ -117,6 +117,10 @@
   button {
       box-shadow: none !important; // How horrible...
 
+      &:focus {
+        text-decoration: underline;
+      }
+
       &.active {
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;


### PR DESCRIPTION
Previously quick question buttons would change in appearance when
focused. The normally used shadow was removed since it would make the
question look horrible.
Instead the button now underlines its text when in focus.