### PR TITLE
Stop nesting for Page fragment 404 errors

### DIFF
--- a/src/app/components/elements/PageFragment.tsx
+++ b/src/app/components/elements/PageFragment.tsx
@@ -1,34 +1,42 @@
-import React, {useEffect} from "react";
+import React, {useEffect, useState} from "react";
 import {AppState} from "../../state/reducers";
 import {ContentDTO} from "../../../IsaacApiTypes";
 import {ShowLoading} from "../handlers/ShowLoading";
 import {IsaacContent} from "../content/IsaacContent";
-import {connect} from "react-redux";
-import {NOT_FOUND_TYPE} from "../../../IsaacAppTypes";
+import {useDispatch, useSelector} from "react-redux";
 import {fetchFragment} from "../../state/actions";
 
-const stateToProps = (state: AppState, {fragmentId}: {fragmentId: string}) => {
-    return {
-        fragment: state && state.fragments && state.fragments[fragmentId] || null
-    };
-};
-const dispatchToProps = {fetchFragment};
 
 interface PageFragmentComponentProps {
     fragmentId: string;
-    fragment: ContentDTO | NOT_FOUND_TYPE | null;
-    fetchFragment: (id: string) => void;
 }
 
-const PageFragmentComponent = ({fragmentId, fragment, fetchFragment}: PageFragmentComponentProps) => {
-    useEffect(
-        () => {fetchFragment(fragmentId);},
-        [fragmentId]
-    );
+export const PageFragment = ({fragmentId}: PageFragmentComponentProps) => {
+    const dispatch = useDispatch();
+    const [pathname, setPathname] = useState("");
+    const fragment = useSelector((state: AppState) => state && state.fragments && state.fragments[fragmentId] || null);
 
-    return <ShowLoading until={fragment} render={(fragment: ContentDTO) =>
+    useEffect(() => {
+        dispatch(fetchFragment(fragmentId))
+        },[fragmentId]);
+
+    useEffect(() => {
+        setPathname(location.pathname);
+    }, [location.pathname]);
+
+    return <ShowLoading until={fragment}
+                        notFound={<div>
+                            <h2> Content not found</h2>
+                            <h3 className="my-4">
+                                <small>
+                                    {"We're sorry, page not found: "}
+                                    <code>
+                                        {pathname}
+                                    </code>
+                                </small>
+                            </h3>
+                        </div>}
+                        render={(fragment: ContentDTO) =>
         <IsaacContent doc={fragment} />
     }/>;
 };
-
-export const PageFragment = connect(stateToProps, dispatchToProps)(PageFragmentComponent);

--- a/src/app/components/handlers/ShowLoading.tsx
+++ b/src/app/components/handlers/ShowLoading.tsx
@@ -9,6 +9,7 @@ interface ShowLoadingProps<T> {
     children?: any;
     placeholder?: ReactElement;
     render?: (t: T) => ReactNode;
+    notFound?: ReactElement;
 }
 
 const defaultPlaceholder = <div className="w-100 text-center">
@@ -16,7 +17,7 @@ const defaultPlaceholder = <div className="w-100 text-center">
     <Spinner color="primary" />
 </div>;
 
-export const ShowLoading = < T extends {} >({until, children, render, placeholder = defaultPlaceholder}: ShowLoadingProps<T>) => {
+export const ShowLoading = < T extends {} >({until, children, render, placeholder = defaultPlaceholder, notFound = <NotFound/>}: ShowLoadingProps<T>) => {
     const [duringLoad, setDuringLoad] = useState(false);
     useEffect( () => {
         let timeout: NodeJS.Timeout;
@@ -42,7 +43,7 @@ export const ShowLoading = < T extends {} >({until, children, render, placeholde
                 return placeholder;
             }
         case NOT_FOUND:
-            return <NotFound/>;
+            return notFound;
         default:
             return children || (render && render(until));
     }


### PR DESCRIPTION
Previously a Page fragment 404 would result in a small 404 page being
shown. Components such as the second breadcrumb bar made this look
strange.

Fixed by allowing a custom 404 element to be shown for ShowLoading
elements.