### PR TITLE
Update Typescript and support optional chaining

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -341,6 +341,7 @@ module.exports = function(webpackEnv) {
                 ),
                 
                 plugins: [
+                  '@babel/plugin-proposal-optional-chaining',
                   [
                     require.resolve('babel-plugin-named-asset-import'),
                     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "isaac-cs-app",
-  "version": "1.0.11-SNAPSHOT",
+  "version": "1.0.12-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6244,7 +6244,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6262,11 +6263,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6279,15 +6282,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6390,7 +6396,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6400,6 +6407,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6412,17 +6420,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6439,6 +6450,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6511,7 +6523,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6521,6 +6534,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6596,7 +6610,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6626,6 +6641,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6643,6 +6659,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6681,11 +6698,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -330,6 +330,16 @@
         "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
       }
     },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.6.0.tgz",
+      "integrity": "sha512-kj4gkZ6qUggkprRq3Uh5KP8XnE1MdIO0J7MhdDX8+rAbB6dJ2UrensGIS+0NPZAaaJ1Vr0PN6oLUgXMU1uMcSg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.2.0"
+      }
+    },
     "@babel/plugin-proposal-unicode-property-regex": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.4.4.tgz",
@@ -400,6 +410,15 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.2.0.tgz",
       "integrity": "sha512-bDe4xKNhb0LI7IvZHiA13kff0KEfaGX/Hv4lMA9+7TEc63hMNvfKo6ZFpXhKuEp+II/q35Gc4NoMeDZyaUbj9w==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.2.0.tgz",
+      "integrity": "sha512-HtGCtvp5Uq/jH/WNUPkK6b7rufnCPLLlDAFN7cmACoIjaOOiXxUt3SswU5loHqrhtqTsa/WoLQ1OQ1AGuZqaWA==",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }
@@ -15347,9 +15366,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "3.3.3333",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
-      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw=="
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ=="
     },
     "ua-parser-js": {
       "version": "0.7.20",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "style-loader": "0.23.1",
     "terser-webpack-plugin": "1.2.2",
     "transfer-webpack-plugin": "^0.1.4",
-    "typescript": "3.3.3333",
+    "typescript": "^3.7.2",
     "url-loader": "1.1.2",
     "webpack": "4.28.3",
     "webpack-dev-server": "3.1.14",
@@ -140,6 +140,7 @@
     "not op_mini all"
   ],
   "devDependencies": {
+    "@babel/plugin-proposal-optional-chaining": "^7.6.0",
     "@types/axios-mock-adapter": "^1.10.0",
     "@types/katex": "^0.10.1",
     "@types/lodash": "^4.14.136",

--- a/src/app/components/elements/Tabs.tsx
+++ b/src/app/components/elements/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useState} from "react";
+import React, {useMemo, useState, ReactNode} from "react";
 import {Nav, NavItem, NavLink, TabContent, TabPane} from "reactstrap";
 
 type StringOrTabFunction = string | ((tabTitle: string, tabIndex: number) => string);
@@ -59,7 +59,7 @@ export const Tabs = (props: TabsProps) => {
             {Object.entries(tabs).map(([tabTitle, tabBody], mapIndex) => {
                 const tabIndex = mapIndex + 1;
                 return <TabPane key={tabTitle} tabId={tabIndex}>
-                    {tabBody}
+                    {tabBody as ReactNode}
                 </TabPane>;
             })}
         </TabContent>

--- a/src/app/components/elements/modals/InequalityModal.tsx
+++ b/src/app/components/elements/modals/InequalityModal.tsx
@@ -159,13 +159,13 @@ export class InequalityModal extends React.Component<InequalityModalProps> {
             inequalityElement.removeChild(inequalityElement.getElementsByTagName('canvas')[0]);
         }
 
-        document.documentElement.style.width = null;
-        document.documentElement.style.height = null;
-        document.documentElement.style.overflow = null;
+        document.documentElement.style.width = '';
+        document.documentElement.style.height = '';
+        document.documentElement.style.overflow = '';
         document.documentElement.style.touchAction = 'auto';
-        document.body.style.width = null;
-        document.body.style.height = null;
-        document.body.style.overflow = null;
+        document.body.style.width = '';
+        document.body.style.height = '';
+        document.body.style.overflow = '';
         document.body.style.touchAction = 'auto';
     }
 

--- a/src/app/components/pages/Homepage.tsx
+++ b/src/app/components/pages/Homepage.tsx
@@ -26,7 +26,7 @@ export const HomepageComponent = ({user}: HomePageProps) => {
                         <Row>
                             <Col>
                                 <h1>{
-                                    user && user.loggedIn ? `Welcome ${user.givenName}!` : "A level Computer Science learning"
+                                    user?.loggedIn ? `Welcome ${user.givenName}!` : "A level Computer Science learning"
                                 }</h1>
                                 <p>
                                     Welcome to Isaac Computer Science, the free online platform for students and teachers.

--- a/src/app/components/pages/SetAssignments.tsx
+++ b/src/app/components/pages/SetAssignments.tsx
@@ -98,7 +98,7 @@ const AssignGroup = ({groups, board, assignBoard}: BoardProps) => {
         </Label>
         <Label className="w-100 pb-2">Due Date Reminder <span className="text-muted"> (optional)</span>
             <DateInput value={dueDate} placeholder="Select your due date..." yearRange={yearRange} defaultYear={currentYear} defaultMonth={currentMonth}
-                onChange={(e: ChangeEvent<HTMLInputElement>) => setDueDate(e.target.valueAsDate)} />
+                onChange={(e: ChangeEvent<HTMLInputElement>) => setDueDate(e.target.valueAsDate as Date)} />
         </Label>
         <Button className="mt-3 mb-2" block color="primary" onClick={assign} disabled={groupId === null}>Assign to group</Button>
     </Container>;
@@ -127,8 +127,8 @@ const Board = (props: BoardProps) => {
                         let selection = window.getSelection();
                         let range = document.createRange();
                         range.selectNodeContents(shareLink.current);
-                        selection.removeAllRanges();
-                        selection.addRange(range);
+                        selection?.removeAllRanges();
+                        selection?.addRange(range);
                     }
                 }
             });


### PR DESCRIPTION
[Typescript 3.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html) is now available and supports optional chaining (aka, safe navigation, aka the Elvis operator).

Say no more to `obj && obj.child && obj.child.id`, you can now just type `obj?.child?.id` and enjoy the rest of your day with all those seconds saved!

**Note**: because we are transpiling TS using Babel, this needs a Babel plugin (until optional chaining gets into Babel's core), because why would you ever run a full TS transpiler when you can simply strip out TS notation, transpile perfectly good JS, and then do the type checking after a few seconds so your website seems to load fine and then a big red error gets in the way? Performance, that's why!

See this: https://trello.com/c/xOtgpU2Q