### PR TITLE
Figure numbering: show Figure N for \ref to figures

### DIFF
--- a/src/app/components/content/IsaacFigure.tsx
+++ b/src/app/components/content/IsaacFigure.tsx
@@ -8,9 +8,14 @@ interface IsaacFigureProps {
     doc: FigureDTO;
 }
 
-// TODO add figure counting and linking
+export function extractFigureId(id: string) {
+    return id.replace(/.*?([^|]*)$/g, '$1');
+}
+
 export const IsaacFigure = ({doc}: IsaacFigureProps) => {
     const path = doc.src && apiHelper.determineImageUrl(doc.src);
+
+    const figId = doc.id && extractFigureId(doc.id);
 
     return <div className="figure_panel">
         <FigureNumberingContext.Consumer>
@@ -20,8 +25,8 @@ export const IsaacFigure = ({doc}: IsaacFigureProps) => {
                     {doc.clickUrl && <a href={doc.clickUrl}><img src={path} alt={doc.altText} /></a>}
                 </div>
                 <div className="text-center figure-caption">
-                    {doc.children && doc.children.length > 0 && doc.id && <div><strong>Figure {figureNumbers[doc.id]}</strong></div>}
-                    <IsaacContentValueOrChildren encoding={doc.encoding} value={doc.value && doc.id && `**Figure ${figureNumbers[doc.id]}:** ${doc.value}`}>
+                    {doc.children && doc.children.length > 0 && figId && <div><strong>Figure {figureNumbers[figId]}</strong></div>}
+                    <IsaacContentValueOrChildren encoding={doc.encoding} value={doc.value && figId && `**Figure ${figureNumbers[figId]}:** ${doc.value}`}>
                         {doc.children}
                     </IsaacContentValueOrChildren>
                     {doc.attribution && <div className="text-muted">{doc.attribution}</div>}

--- a/src/app/components/elements/TrustedMarkdown.tsx
+++ b/src/app/components/elements/TrustedMarkdown.tsx
@@ -107,7 +107,6 @@ export const TrustedMarkdown = ({markdown}: {markdown: string}) => {
 
     // RegEx replacements to match Latex inspired Isaac Physics functionality
     const regexRules = {
-        "<span isaac-figure-ref='$2'></span>": /(~D)?\\ref{([^}]*)}(~D)?/g,
         "[$1]($2)": /\\link{([^}]*)}{([^}]*)}/g,
         "[**Glossary**](/glossary)": /\*\*Glossary\*\*/g,
         // "[**Concepts**](/concepts)": /\*\*Concepts\*\*/g,

--- a/src/app/components/elements/WithFigureNumbering.tsx
+++ b/src/app/components/elements/WithFigureNumbering.tsx
@@ -1,6 +1,7 @@
 import {ContentDTO} from "../../../IsaacApiTypes";
 import {FigureNumberingContext, FigureNumbersById} from "../../../IsaacAppTypes";
 import React from "react";
+import {extractFigureId} from "../content/IsaacFigure";
 
 interface WithFigureNumberingProps {
     doc: ContentDTO;
@@ -16,7 +17,7 @@ export const WithFigureNumbering = ({doc, children}: WithFigureNumberingProps) =
             // Nothing to see here. Move along.
             return;
         } else if (d.type == "figure" && d.id) {
-            figureNumbers[d.id] = n++;
+            figureNumbers[extractFigureId(d.id)] = n++;
         } else {
             // Walk all the things that might possibly contain figures. Doesn't blow up if they don't exist.
             for (let c of d.children || []) {

--- a/src/test/components/TrustedHtml.test.tsx
+++ b/src/test/components/TrustedHtml.test.tsx
@@ -27,7 +27,7 @@ describe('TrustedHtml LaTeX locator', () => {
     it('can find basic delimiters', () => {
         delimiters.forEach(([open, displayMode, close]) => {
             const testcase = html[0] + wrapIn(open, math[0], close) + html[1];
-            const result = katexify(testcase, null, null, false);
+            const result = katexify(testcase, null, null, false, {});
 
             expect(result).toEqual(html[0] + LATEX + html[1]);
             // @ts-ignore
@@ -40,7 +40,7 @@ describe('TrustedHtml LaTeX locator', () => {
     it("unbalanced delimiters don't break everything but instead are just skipped", () => {
         delimiters.forEach(([open, , ]) => {
             const testcase = html[0] + wrapIn(open, math[0], "") + html[1];
-            const result = katexify(testcase, null, null, false);
+            const result = katexify(testcase, null, null, false, {});
 
             expect(result).toEqual(html[0] + open + math[0] + html[1]);
             expect(katex.renderToString).not.toHaveBeenCalled();
@@ -51,7 +51,7 @@ describe('TrustedHtml LaTeX locator', () => {
         nestedDollars.forEach((dollarMath) => {
             delimiters.forEach(([open, displayMode, close]) => {
                 const testcase = html[0] + wrapIn(open, dollarMath, close) + html[1];
-                const result = katexify(testcase, null, null, false);
+                const result = katexify(testcase, null, null, false, {});
 
                 expect(result).toEqual(html[0] + LATEX + html[1]);
                 // @ts-ignore
@@ -65,7 +65,7 @@ describe('TrustedHtml LaTeX locator', () => {
     it('can render environments', () => {
         const env = "\\begin{aligned}" + math[0] + "\\end{aligned}";
         const testcase = html[0] + env + html[1];
-        const result = katexify(testcase, null, null, false);
+        const result = katexify(testcase, null, null, false, {});
 
         expect(result).toEqual(html[0] + LATEX + html[1]);
         // @ts-ignore
@@ -74,12 +74,21 @@ describe('TrustedHtml LaTeX locator', () => {
         expect(callArgs[1]).toMatchObject({"displayMode": true});
     });
 
-    it('refs are currently ignored', () => {
+    it('missing refs show an inline error', () => {
         const ref = "\\ref{foo[234o89tdgfiuno34£\"$%^Y}";
         const testcase = html[0] + ref + html[1];
-        const result = katexify(testcase, null, null, false);
+        const result = katexify(testcase, null, null, false, {});
 
-        expect(result).toEqual(html[0] + ref + html[1]);
+        expect(result).toEqual(html[0] + "unknown reference " + ref + html[1]);
+        expect(katex.renderToString).not.toHaveBeenCalled();
+    });
+
+    it('found refs show their figure number', () => {
+        const ref = "\\ref{foo}";
+        const testcase = html[0] + ref + html[1];
+        const result = katexify(testcase, null, null, false, {foo: 42});
+
+        expect(result).toEqual(html[0] + "Figure 42" + html[1]);
         expect(katex.renderToString).not.toHaveBeenCalled();
     });
 
@@ -87,7 +96,7 @@ describe('TrustedHtml LaTeX locator', () => {
         const escapedDollar = "\\$";
         const unescapedDollar = "$";
         const testcase = html[0] + escapedDollar + html[1];
-        const result = katexify(testcase, null, null, false);
+        const result = katexify(testcase, null, null, false, {});
 
         expect(result).toEqual(html[0] + unescapedDollar + html[1]);
         expect(katex.renderToString).not.toHaveBeenCalled();


### PR DESCRIPTION
The logic of figure identifiers is the same as in the Angular system.

I haven't implemented any kind of hyperlinking; that seems like an extra feature and might not be that clear.