### PR TITLE
Restyle and rename class to differentiate event cards from news

### DIFF
--- a/src/app/components/elements/cards/EventCard.tsx
+++ b/src/app/components/elements/cards/EventCard.tsx
@@ -9,7 +9,7 @@ export const EventCard = ({event, pod = false}: {event: AugmentedEvent; pod?: bo
     const {id, title, subtitle, eventThumbnail, location, expired, date, endDate, multiDay} = event;
 
     return <RS.Card className={classnames({'card-neat': true, 'disabled text-muted': expired, 'm-4': pod, 'mb-4': !pod})}>
-        {eventThumbnail && <div className={'card-image text-center mt-3'}>
+        {eventThumbnail && <div className={'event-card-image text-center mt-3'}>
             <RS.CardImg
                 className={'m-auto rounded-circle'} top
                 src={eventThumbnail.src} alt={eventThumbnail.altText || `Illustration for ${title}`}

--- a/src/app/components/elements/cards/NewsCard.tsx
+++ b/src/app/components/elements/cards/NewsCard.tsx
@@ -9,7 +9,7 @@ export const NewsCard = ({newsItem}: {newsItem: IsaacPodDTO}) => {
     const {title, value, image, url} = newsItem;
 
     return <RS.Card className={classnames({'card-neat': true, 'news-carousel': true, 'm-4': true})}>
-        {image && <div className={'card-image'}>
+        {image && <div>
             <RS.CardImg
                 className={'news-card-image'}
                 top

--- a/src/scss/cards.scss
+++ b/src/scss/cards.scss
@@ -10,11 +10,8 @@
   @include respond-above(sm) {
     box-shadow: 0 2px 30px 0 $shadow-08;
   }
-  .news-carousel & .card-image {
+  .news-card-image {
     @include aspect-ratio(100, 59);
-    > .card-image img {
-      left: -1.45rem !important;
-    }
   }
   // Nomensa's image offset code, if we decide to use
   //.news-card-image {

--- a/src/scss/cards.scss
+++ b/src/scss/cards.scss
@@ -21,7 +21,7 @@
   //  //margin-left: -1.45rem;
   //  //width: calc(100% - 0.5rem) !important;
   //}
-  .events-carousel & .card-image {
+  .event-card-image {
     img {
       display: block;
       height: 150px;

--- a/src/scss/homepage.scss
+++ b/src/scss/homepage.scss
@@ -39,14 +39,6 @@
     }
   }
 
-  section#events {
-    img {
-      height: 151px !important;
-      width: 151px !important;
-      margin: 1rem;
-    }
-  }
-
   //section#sign-up-card {
   //  border: black 1px solid;
   //}


### PR DESCRIPTION
Now we have an events page as well as the homepage, the override styling on the homepage appears redundant and adds confusion so I removed it. Now event card images have their own class 